### PR TITLE
fix(ci): update v4 deploy host to new EC2 IP

### DIFF
--- a/.github/workflows/deploy-v4.yml
+++ b/.github/workflows/deploy-v4.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Deploy to V4 EC2 via SSH
         uses: appleboy/ssh-action@v1
         with:
-          host: 3.15.173.79
+          host: 3.136.160.66
           username: ${{ secrets.V4_DEPLOY_USER }}
           key: ${{ secrets.V4_DEPLOY_SSH_KEY }}
           command_timeout: 30m


### PR DESCRIPTION
## Summary
- `v4-temp-server` was resized from `t4g.large` → `t4g.xlarge`, which released the old public IP `3.15.173.79`.
- New IP is `3.136.160.66`.
- `.github/workflows/deploy-v4.yml` had the old IP hardcoded → any merge to develop would deploy-fail with `i/o timeout` (same failure we just saw in gig-v4-backend PR #22).
- This PR points the v4 deploy at the new IP.

Mirrors gig-v4-backend PR #23.

## Follow-up
- Attach an Elastic IP to `v4-temp-server` so it doesn't change again on the next stop/start.
- Move `host:` into a GitHub Actions variable so future IP changes don't need a PR per repo.

## Test plan
- [ ] Merge → deploy workflow connects (no `i/o timeout`)
- [ ] Verify `v4-employee-app` PM2 process picks up changes