### PR TITLE
fix(ci): read v4 deploy host from V4_DEPLOY_HOST variable

### DIFF
--- a/.github/workflows/deploy-v4.yml
+++ b/.github/workflows/deploy-v4.yml
@@ -17,7 +17,15 @@ jobs:
       - name: Deploy to V4 EC2 via SSH
         uses: appleboy/ssh-action@v1
         with:
-          host: 3.136.160.66
+          # Host comes from the `V4_DEPLOY_HOST` repo/environment Variable rather
+          # than a hardcoded IP. The v4 EC2 box has an ephemeral public IP that
+          # changes whenever it is stopped/started (a stop/start already broke
+          # this deploy once — see #142), so hardcoding forces a code change +
+          # PR every time. With a Variable, an IP change is a one-field edit in
+          # Settings → Variables (no deploy code churn).
+          #   Permanent fix: attach an Elastic IP to the box and point
+          #   V4_DEPLOY_HOST at it once — then it never drifts again.
+          host: ${{ vars.V4_DEPLOY_HOST }}
           username: ${{ secrets.V4_DEPLOY_USER }}
           key: ${{ secrets.V4_DEPLOY_SSH_KEY }}
           command_timeout: 30m


### PR DESCRIPTION
## Problem
The **Deploy V4 (Clerk)** workflow SSHes into a hardcoded EC2 IP (`3.136.160.66`) and has failed **every `develop` deploy since ~2026-06-24** with:
```
dial tcp 3.136.160.66:22: i/o timeout
```
The v4 EC2 box has an **ephemeral public IP** that changes on every stop/start. This already broke once and was hand-patched in #142 ("update v4 deploy host to new EC2 IP after resize"). It drifted again — the hardcoded IP is stale.

This is **not** caused by the QR feature (#143) — that merged fine and deployed via *Deploy to Dev* (EB). This is a pre-existing infra/CI fragility.

## Fix
Read the SSH host from a repo/environment **Variable** `V4_DEPLOY_HOST` instead of hardcoding it, so an IP change is a one-field Settings edit — no code change or PR.

## ⚠️ Required before this helps (pick one)
1. **Permanent (recommended):** attach an **Elastic IP** to the v4 EC2 box, then set repo Variable `V4_DEPLOY_HOST` = that EIP once. It never drifts again.
2. **Quick:** set `V4_DEPLOY_HOST` = the box's *current* public IP (breaks again on next stop/start).

Set it at **Settings → Secrets and variables → Actions → Variables** (or the `v4-develop` environment). Until it's set, the deploy will fail on an empty host — so merge **after** setting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)