### PR TITLE
fix(ci): deploy employee Dev as V4 (Clerk) against the v4 Mongo

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,8 +8,13 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy-eb-reusable.yaml
     with:
-      environment: develop
+      # Deploy Dev through the v4-develop environment: it carries the Clerk keys
+      # and the v4 tenant Mongo URI, so the employee app runs as the V4 (Clerk)
+      # build against the same database the v4 admin/backend use. is_v4=true
+      # flips the build-time auth layer from Auth0 to Clerk.
+      environment: v4-develop
       eb_env_name: employee-app-dev
       eb_app_name: employee-app
       s3_key_prefix: employee-app/dev
+      is_v4: 'true'
     secrets: inherit

--- a/.github/workflows/deploy-eb-reusable.yaml
+++ b/.github/workflows/deploy-eb-reusable.yaml
@@ -18,6 +18,11 @@ on:
       s3_key_prefix:
         required: true
         type: string
+      is_v4:
+        description: When 'true', build/run the V4 (Clerk) variant instead of legacy Auth0.
+        required: false
+        type: string
+        default: 'false'
     secrets:
       AUTH0_SECRET:
         required: true
@@ -25,6 +30,8 @@ on:
         required: true
       MONGODB_CONNECTION_STRING:
         required: true
+      CLERK_SECRET_KEY:
+        required: false
       NEXT_PUBLIC_GOOGLE_MAPS_API_KEY:
         required: true
       GOOGLE_MAPS_API_KEY_TWO:
@@ -127,5 +134,7 @@ jobs:
                 "Namespace=aws:elasticbeanstalk:application:environment,OptionName=SP1_API_ORIGIN,Value=${{ vars.SP1_API_ORIGIN }}" \
                 "Namespace=aws:elasticbeanstalk:application:environment,OptionName=CLUSTER_ENABLED,Value=${{ vars.CLUSTER_ENABLED }}" \
                 "Namespace=aws:elasticbeanstalk:application:environment,OptionName=CLUSTER_WORKERS,Value=${{ vars.CLUSTER_WORKERS }}" \
-                "Namespace=aws:elasticbeanstalk:application:environment,OptionName=IS_V4,Value=false" \
-                "Namespace=aws:elasticbeanstalk:application:environment,OptionName=NEXT_PUBLIC_IS_V4,Value=false"
+                "Namespace=aws:elasticbeanstalk:application:environment,OptionName=IS_V4,Value=${{ inputs.is_v4 }}" \
+                "Namespace=aws:elasticbeanstalk:application:environment,OptionName=NEXT_PUBLIC_IS_V4,Value=${{ inputs.is_v4 }}" \
+                "Namespace=aws:elasticbeanstalk:application:environment,OptionName=NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,Value=${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}" \
+                "Namespace=aws:elasticbeanstalk:application:environment,OptionName=CLERK_SECRET_KEY,Value=${{ secrets.CLERK_SECRET_KEY }}"


### PR DESCRIPTION
## Problem
The employee **Deploy to Dev** (EB `employee-app-dev`) was provisioned as the **legacy Auth0** build and can't function as the v4 employee app:
- `deploy-eb-reusable.yaml` hardcoded **`IS_V4=false` / `NEXT_PUBLIC_IS_V4=false`** → built with the Auth0 auth layer, not Clerk; passed **no Clerk keys**.
- Deployed through the **`develop`** GitHub environment, whose `MONGODB_CONNECTION_STRING` is the **legacy DB** — not the v4 tenant Mongo the admin/backend read. So the employee app's `/api` wrote `clockInQr` to a **different database** than the QR redeem reads → the QR round-trip could never work.

## Fix
Route the Dev deploy through the **`v4-develop`** GitHub environment (which already has `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, and the **v4 Mongo** URI — the same one the old v4 SSH box used), and turn on the v4 build:
- **`deploy-dev.yml`**: `environment: develop` → `v4-develop`, add `is_v4: 'true'`.
- **`deploy-eb-reusable.yaml`**: new `is_v4` input (default `'false'`), drive `IS_V4`/`NEXT_PUBLIC_IS_V4` from it, pass Clerk publishable + secret keys through to EB.

The build runs on the EB instance **after** these env vars are set, so the `NEXT_PUBLIC_*` Clerk/v4 values inline correctly — no runner rebuild needed.

**Stage/Prod untouched:** they don't pass `is_v4` (defaults to `'false'`) and `CLERK_SECRET_KEY` is an optional secret, so they keep building Auth0 exactly as before.

## After merge
Deploying develop redeploys `employee-app-dev` as the **Clerk/v4** employee app against the **v4 tenant Mongo** — so the QR feature can be tested end-to-end against the same DB as the admin app. (Clerk is in dev mode → no dashboard/origin changes needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)