### PR TITLE
revert(ci): point employee Dev back to develop env (restore service)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,13 +8,14 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy-eb-reusable.yaml
     with:
-      # Deploy Dev through the v4-develop environment: it carries the Clerk keys
-      # and the v4 tenant Mongo URI, so the employee app runs as the V4 (Clerk)
-      # build against the same database the v4 admin/backend use. is_v4=true
-      # flips the build-time auth layer from Auth0 to Clerk.
-      environment: v4-develop
+      # NOTE: reverted from the v4-develop / is_v4:true switch — the
+      # employee-app-dev EB box has no network path to the v4 Mongo/Redis
+      # (server-selection timeout → app hung on "Checking authentication").
+      # Re-enable the v4 cutover only after the box's egress IP is added to the
+      # v4 Atlas allowlist AND it can reach the v4 Redis. The reusable still
+      # supports is_v4 for when that's ready.
+      environment: develop
       eb_env_name: employee-app-dev
       eb_app_name: employee-app
       s3_key_prefix: employee-app/dev
-      is_v4: 'true'
     secrets: inherit


### PR DESCRIPTION
Reverts the `v4-develop` / `is_v4:true` switch (#147) — it took **Dev down**.

**Why:** the `employee-app-dev` EB box has **no network path to the v4 Mongo/Redis**. Every DB/Redis-touching request hung for 30s (Mongo server-selection timeout), so authenticated `/api/auth/me` never resolved → app stuck on *"Checking authentication…"*. `/api/health` and the QR route hung too; unauthenticated `/api/auth/me` (no DB) returned 204 in 1.4s.

**Fix:** point Dev back to the `develop` environment (Auth0 + legacy Mongo/Redis, which the box **can** reach) to restore service. The reusable keeps `is_v4` support so we can re-cut to v4 later — **once the box is networked to the v4 infra** (add its egress IP to the v4 Atlas allowlist + ensure v4 Redis reachability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)