### PR TITLE
fix(ci): re-enable employee Dev V4/Clerk (with reachable Redis)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -8,14 +8,15 @@ jobs:
   deploy:
     uses: ./.github/workflows/deploy-eb-reusable.yaml
     with:
-      # NOTE: reverted from the v4-develop / is_v4:true switch — the
-      # employee-app-dev EB box has no network path to the v4 Mongo/Redis
-      # (server-selection timeout → app hung on "Checking authentication").
-      # Re-enable the v4 cutover only after the box's egress IP is added to the
-      # v4 Atlas allowlist AND it can reach the v4 Redis. The reusable still
-      # supports is_v4 for when that's ready.
-      environment: develop
+      # V4 (Clerk) build against the v4 tenant Mongo. The v4-develop env's
+      # Redis host + NEXT_PUBLIC_API_URL were aligned to the employee-app-dev
+      # box's own reachable ElastiCache + domain (the original v4-develop values
+      # pointed at an unreachable "v4-temporary" serverless Redis in another VPC,
+      # which hung the app on "Checking authentication"). Mongo egress
+      # (NAT 3.12.228.123) is already on the v4 Atlas allowlist.
+      environment: v4-develop
       eb_env_name: employee-app-dev
       eb_app_name: employee-app
       s3_key_prefix: employee-app/dev
+      is_v4: 'true'
     secrets: inherit


### PR DESCRIPTION
Re-applies the Clerk/v4 switch after fixing the real blocker. The prior attempt hung because `v4-develop` pointed at an unreachable **v4-temporary serverless Redis** in another VPC (not a Mongo/Atlas issue — the box's NAT egress `3.12.228.123` is already allowlisted). Aligned `v4-develop`'s Redis host + API URL to the box's own reachable ElastiCache + domain; keeps v4 Mongo + Clerk + IS_V4. Stage/Prod untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)