### PR TITLE
fix(auth): let OTP sessions through the protected-route middleware

### DIFF
--- a/src/lib/middleware/clerk.ts
+++ b/src/lib/middleware/clerk.ts
@@ -12,7 +12,14 @@ const isProtected = createRouteMatcher(
 const clerkHandler = clerkMiddleware(async (auth, req) => {
   if (isProtected(req)) {
     const { userId, redirectToSignIn } = await auth();
-    if (!userId) return redirectToSignIn();
+    // V4 supports two session types: Clerk (userId) and the Redis-backed OTP
+    // email-code flow (an `otp_session_id` cookie, no Clerk userId). Let an
+    // OTP-authenticated request through — the page's client guard and the
+    // withEnhancedAuthAPI handlers still validate the session for real. Without
+    // this, OTP users get bounced to Clerk sign-in on every protected route
+    // (e.g. /profile, /dashboard).
+    const hasOtpSession = !!req.cookies.get('otp_session_id')?.value;
+    if (!userId && !hasOtpSession) return redirectToSignIn();
   }
 });
 


### PR DESCRIPTION
The V4 Clerk middleware protected `/profile`, `/dashboard`, `/jobs` etc. with a **Clerk-only** `auth().userId` check. Users who sign in via the **email OTP** flow have a Redis-backed `otp_session_id` session and no Clerk `userId`, so they were bounced to Clerk's hosted sign-in on every protected route (client-gated routes like `/home` worked). Now a request with an `otp_session_id` cookie passes the guard — the page's client `usePageAuth` and the `withEnhancedAuthAPI` handlers still validate it; only truly-unauthenticated requests redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)