### PR TITLE
fix(auth): redirect already-signed-in users off /sign-in to home

### DIFF
--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,13 +1,45 @@
 'use client';
 
-import { notFound, useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
+import { notFound, useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
 import { IS_V4 } from '@/lib/config/auth-mode';
 import { CustomSignInForm } from '@/components/auth/CustomSignInForm';
+import { useAppUser } from '@/domains/user/hooks/useAppUser';
 
 function SignInInner() {
   const params = useSearchParams();
   const redirectUrl = params.get('redirect_url') ?? '/';
+  const router = useRouter();
+  // Resolves the current user from either auth source (Clerk or the OTP
+  // session) via /api/auth/me.
+  const { user, isLoading } = useAppUser();
+
+  // Already signed in? Don't show the form — send them home. Without this, a
+  // user who lands on /sign-in while still authenticated (a stale link, a
+  // session-refresh bounce, or the back button) gets stuck staring at the
+  // sign-in form even though their session is valid. Destination mirrors the
+  // "/" landing (see app/page.tsx): Home for full users, else their surface.
+  useEffect(() => {
+    if (user && !isLoading) {
+      const isApplicantOnly = user.isApplicantOnly ?? false;
+      const isLimitedAccess = user.isLimitedAccess ?? false;
+      let dest = '/home';
+      if (isApplicantOnly) dest = '/applicant';
+      else if (isLimitedAccess) dest = '/payroll';
+      router.replace(dest);
+    }
+  }, [user, isLoading, router]);
+
+  // While auth is resolving, or while redirecting an already-signed-in user,
+  // show a spinner instead of flashing the sign-in form.
+  if (isLoading || user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <div className="h-12 w-12 animate-spin rounded-full border-b-[3px] border-appPrimary" />
+      </div>
+    );
+  }
+
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
       <div className="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-8 shadow-sm">


### PR DESCRIPTION
Signed-in users who landed on `/sign-in` (stale link, session-refresh bounce, back button) got stuck on the sign-in form even though their session was valid. The `/` landing already redirects authed users home; `/sign-in` didn't.

Adds the same guard: resolve the current user via `useAppUser` (handles both Clerk and OTP sessions) and, if present, `router.replace` to their home surface (`/home`, else `/applicant` / `/payroll`) — with a spinner instead of a flash of the form while auth resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)