### PR TITLE
fix(csp): allow Clerk custom domains under *.gignology.biz

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -124,6 +124,7 @@ const nextConfig = {
       'https://*.clerk.accounts.dev', // Clerk (dev)
       'https://*.clerk.com', // Clerk (prod)
       'https://clerk-telemetry.com',
+      'https://*.gignology.biz', // Clerk custom domains (clerk.employee.gignology.biz) + V4 API
     ];
 
     const frameSrc = [
@@ -145,7 +146,7 @@ const nextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://maps.googleapis.com https://*.gstatic.com https://polyfill.io https://*.clerk.accounts.dev https://*.clerk.com",
+              "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://maps.googleapis.com https://*.gstatic.com https://polyfill.io https://*.clerk.accounts.dev https://*.clerk.com https://*.gignology.biz",
               "worker-src 'self' blob:",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: https: blob:",

--- a/src/lib/middleware/security.ts
+++ b/src/lib/middleware/security.ts
@@ -38,7 +38,7 @@ export async function securityMiddleware(): Promise<NextResponse | null> {
     'Content-Security-Policy',
     [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://maps.googleapis.com https://*.gstatic.com https://*.clerk.accounts.dev https://*.clerk.com",
+      "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://maps.googleapis.com https://*.gstatic.com https://*.clerk.accounts.dev https://*.clerk.com https://*.gignology.biz",
       "worker-src 'self' blob:",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "img-src 'self' data: https: blob:",


### PR DESCRIPTION
Emergency prod fix already shipped as tag v1.0.51 (tags deploy from their own ref). This PR syncs main with staging so future tags include the CSP fix.

CSP script-src and connect-src now allow https://*.gignology.biz — the prod Clerk instances moved to custom domains (clerk.employee.gignology.biz / clerk.gignology.biz) and clerk-js was being blocked, rendering the employee app blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)