### PR TITLE
fix(images): resolve tenant assets from S3, not legacy EFS host

### DIFF
--- a/src/app/events/components/ClientEventDetailModal.tsx
+++ b/src/app/events/components/ClientEventDetailModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { resolveImageUrl } from '@/lib/utils/resolve-image-url';
 import dynamic from 'next/dynamic';
 import 'react-quill/dist/quill.snow.css';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
@@ -1297,7 +1298,8 @@ function AttachmentsPanel({
     if (previewUrl) return previewUrl;
     const imgFile = event.eventImage || event.logoUrl;
     if (!imgFile) return null;
-    if (imgFile.startsWith('http')) return imgFile;
+    if (imgFile.startsWith('http'))
+      return resolveImageUrl(imgFile, imageBaseUrl) ?? null;
     return `${imageBaseUrl}/${event.venueSlug}/events/${event.eventUrl}/${imgFile}`;
   }
 

--- a/src/app/events/components/ClientEventsView.tsx
+++ b/src/app/events/components/ClientEventsView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { resolveImageUrl } from '@/lib/utils/resolve-image-url';
 import {
   Zap,
   History,
@@ -350,7 +351,8 @@ export default function ClientEventsView() {
 
   function getLogoUrl(event: GignologyEvent): string | null {
     if (!event.logoUrl) return null;
-    if (event.logoUrl.startsWith('http')) return event.logoUrl;
+    if (event.logoUrl.startsWith('http'))
+      return resolveImageUrl(event.logoUrl, imageBaseUrl) ?? null;
     return `${imageBaseUrl}/${event.venueSlug}/venues/logo/${event.logoUrl}`;
   }
 

--- a/src/domains/company/utils/mongo-company-utils.ts
+++ b/src/domains/company/utils/mongo-company-utils.ts
@@ -1,12 +1,14 @@
 import type { Db } from 'mongodb';
 import { Company } from '../types';
 import { convertToJSON } from '@/lib/utils/mongo-utils';
+import { buildTenantImageBase } from '@/lib/utils/tenant-image-base';
 
 export async function findPrimaryCompany(db: Db): Promise<Company | null> {
   try {
     const projection = {
       _id: 1,
       name: 1,
+      slug: 1,
       imageUrl: 1,
       timeClockSettings: 1,
       uploadPath: 1,
@@ -23,6 +25,18 @@ export async function findPrimaryCompany(db: Db): Promise<Company | null> {
     }
 
     const company = convertToJSON(companyDoc) as Company;
+
+    // Point the tenant asset base at S3 instead of the stored legacy EFS host
+    // (`https://images.stadiumpeople.com/sp`). v4 writes uploads only to S3, so
+    // the EFS host 404s anything created/updated in v4 (e.g. new venue logos &
+    // banners). Every consumer builds `${imageUrl}/${slug}/venues|events/...` or
+    // `/users/{id}/photo/...`, so swapping just the base fixes all of them and
+    // keeps already-migrated assets working (they exist in S3 too).
+    const s3Base = buildTenantImageBase(companyDoc.slug as string | undefined);
+    if (s3Base) {
+      company.imageUrl = s3Base;
+    }
+
     return company;
   } catch (error) {
     console.error('Error finding primary company:', error);

--- a/src/domains/event/components/EventCard/EventCard.tsx
+++ b/src/domains/event/components/EventCard/EventCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { resolveImageUrl } from '@/lib/utils/resolve-image-url';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { MapPin, Clock, ImageIcon, Users, Hash, Check, HelpCircle } from 'lucide-react';
 import { Badge } from '@/components/ui/Badge';
@@ -165,7 +166,7 @@ export const EventCard = ({
   const fullLogoUrl =
     logoFilename && !logoError
       ? logoFilename.startsWith('http')
-        ? logoFilename
+        ? resolveImageUrl(logoFilename, imageBaseUrl)
         : `${imageBaseUrl}/${event.venueSlug}/venues/logo/${logoFilename}`
       : null;
 

--- a/src/domains/event/components/EventDetailModal/EventDetailModal.tsx
+++ b/src/domains/event/components/EventDetailModal/EventDetailModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo } from 'react';
+import { resolveImageUrl } from '@/lib/utils/resolve-image-url';
 import {
   MapPin,
   Calendar,
@@ -428,7 +429,7 @@ export const EventDetailModal = ({
   const fullLogoUrl =
     logoFilename && !logoError
       ? logoFilename.startsWith('http')
-        ? logoFilename
+        ? resolveImageUrl(logoFilename, imageBaseUrl)
         : `${imageBaseUrl}/${event.venueSlug}/venues/logo/${logoFilename}`
       : null;
 

--- a/src/domains/event/components/EventDetailView/EventDetailView.tsx
+++ b/src/domains/event/components/EventDetailView/EventDetailView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo } from 'react';
+import { resolveImageUrl } from '@/lib/utils/resolve-image-url';
 import {
   MapPin,
   Building2,
@@ -422,7 +423,7 @@ export const EventDetailView = ({
   const fullLogoUrl =
     logoFilename && !logoError
       ? logoFilename.startsWith('http')
-        ? logoFilename
+        ? resolveImageUrl(logoFilename, imageBaseUrl)
         : `${imageBaseUrl}/${event.venueSlug}/venues/logo/${logoFilename}`
       : null;
 

--- a/src/lib/utils/resolve-image-url.ts
+++ b/src/lib/utils/resolve-image-url.ts
@@ -1,0 +1,55 @@
+/**
+ * Rewrite a stored image URL to S3 when it points at a legacy EFS/nginx host.
+ *
+ * Most events store `logoUrl` as a FULL legacy URL, e.g.
+ *   https://images.stadiumpeople.com/sp/ford/venues/logo/ford-venuelogo.png
+ * and the event components use it verbatim — so those logos still load from EFS
+ * even though v4 writes uploads only to S3 (new/updated ones would 404 there).
+ * This rewrites such URLs to the tenant S3 bucket, dropping the leading
+ * uploadPath segment ("sp"/"sterling"/…) exactly like gignology-v4's
+ * resolveImageUrl / the backend's rewriteEventLogoUrl:
+ *   .../sp/ford/venues/logo/x.png  →  {s3Base}/ford/venues/logo/x.png
+ *
+ * Client-safe: the S3 base is passed in (the `imageBaseUrl` the components
+ * already hold, which findPrimaryCompany now sets to the S3 bucket) — no env
+ * access needed in the browser.
+ */
+
+const OLD_IMAGE_HOSTS = [
+  "images.stadiumpeople.com",
+  "images.dev.gignology.biz",
+  "images.v4.gignology.biz",
+];
+
+export function resolveImageUrl(
+  url: string | null | undefined,
+  s3Base: string | null | undefined,
+): string | null | undefined {
+  if (!url) return url;
+
+  // Already an S3 URL — leave as-is.
+  if (url.includes(".s3.") && url.includes("amazonaws.com")) return url;
+
+  // Legacy EFS/nginx host — rewrite to the tenant S3 bucket.
+  for (const host of OLD_IMAGE_HOSTS) {
+    if (url.includes(host)) {
+      if (!s3Base) return url; // no base to rewrite to; leave untouched
+      try {
+        const u = new URL(url);
+        // Drop the leading uploadPath segment: the migrated S3 object lives
+        // WITHOUT it (the prefixed key 403s). Keep pathname encoding intact.
+        const segments = u.pathname.split("/").filter(Boolean);
+        const key =
+          segments.length >= 2
+            ? segments.slice(1).join("/")
+            : segments.join("/");
+        return `${s3Base.replace(/\/$/, "")}/${key}`;
+      } catch {
+        return url;
+      }
+    }
+  }
+
+  // Any other absolute URL — leave as-is.
+  return url;
+}

--- a/src/lib/utils/tenant-image-base.ts
+++ b/src/lib/utils/tenant-image-base.ts
@@ -1,0 +1,29 @@
+/**
+ * Build the public S3 base URL for a tenant's asset bucket.
+ *
+ * All images (venue logos/banners, event attachments, user photos) moved from
+ * the legacy EFS/nginx host (`https://images.stadiumpeople.com/sp`) to per-tenant
+ * S3 buckets. gig-v4-backend writes uploads ONLY to S3 now, so the legacy host is
+ * missing anything created/updated in v4 — which is why new venues' logos/banners
+ * 404 in this app while gignology-v4 (which points at S3) shows them.
+ *
+ * Bucket naming mirrors the backend's `S3StorageService.getTenantBucketName`
+ * EXACTLY so this always points where the object actually lives:
+ *   Production: gignology-{slug}-prod
+ *   Stage/Dev:  gignology-{slug}-stage
+ * (suffix keyed off NODE_ENV, same as the backend).
+ *
+ * The S3 key drops the legacy uploadPath segment ("sp"/…): objects live at
+ * `{venueSlug}/venues/logo/{file}`, NOT `sp/{venueSlug}/…`. Since every consumer
+ * builds `${base}/${slug}/venues/...`, returning a base WITHOUT the `/sp` suffix
+ * (unlike the old `imageUrl`) yields the correct S3 URL for free.
+ */
+export function buildTenantImageBase(
+  slug: string | null | undefined,
+): string | undefined {
+  if (!slug) return undefined;
+  const sanitized = slug.toLowerCase().replace(/[^a-z0-9-]/g, "-");
+  const region = process.env.AWS_REGION || "us-east-2";
+  const suffix = process.env.NODE_ENV === "production" ? "prod" : "stage";
+  return `https://gignology-${sanitized}-${suffix}.s3.${region}.amazonaws.com`;
+}


### PR DESCRIPTION
### Problem
Venue logos/banners (and event images + user photos) were built from the stored `company.imageUrl` — the legacy EFS host `https://images.stadiumpeople.com/sp`. v4 writes uploads **only to S3**, so anything created/updated in v4 (e.g. new venue logos & banners) 404s on EFS and shows blank here, while gignology-v4 (which points at S3) renders it.

Verified with curl: new venue (TestBanner) logo → EFS **404**, S3 **200**; already-working venues (285 Lacrosse, ATestVenue) → S3 **200** too.

### Fix
`findPrimaryCompany` now overrides `imageUrl` with the per-tenant S3 bucket base, mirroring the backend's `S3StorageService.getTenantBucketName` exactly — `gignology-{slug}-{stage|prod}` (suffix off `NODE_ENV`, region off `AWS_REGION`) — and dropping the legacy `/sp` uploadPath segment.

Every consumer builds `${imageUrl}/${slug}/venues|events/...` or `/users/{id}/photo/...`, so this one swap fixes all image surfaces at once and keeps already-migrated assets working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)