### PR TITLE
fix(auth): make "Manage account" work for OTP-authenticated users

### DIFF
--- a/src/app/api/auth/clerk-bridge/route.ts
+++ b/src/app/api/auth/clerk-bridge/route.ts
@@ -1,0 +1,58 @@
+// app/api/auth/clerk-bridge/route.ts
+//
+// Bridges an OTP-authenticated session into a Clerk sign-in "ticket" so the
+// user can open Clerk's account modal ("Manage account"), which requires a real
+// Clerk session. OTP login only creates a custom Redis session (otp_session_*),
+// not a Clerk session — so openUserProfile() silently no-ops for those users.
+//
+// The user must ALREADY exist in the (gignology) Clerk instance — we never
+// create one here. That means no provisioning, no Clerk MAU churn from users
+// who never open this, and no `user.created` webhook side effects. When there's
+// no Clerk account for the email we return { hasClerkUser: false } so the UI can
+// degrade gracefully instead of erroring.
+import { NextRequest, NextResponse } from 'next/server';
+import redisService from '@/lib/cache/redis-client';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  try {
+    // 1. Authenticate via the existing OTP session cookie (server-side).
+    const sessionId = request.cookies.get('otp_session_id')?.value;
+    if (!sessionId) {
+      return NextResponse.json({ error: 'no-otp-session' }, { status: 401 });
+    }
+    const session = await redisService.get<{ email?: string }>(
+      `otp_session:${sessionId}`
+    );
+    const email = session?.email?.toLowerCase().trim();
+    if (!email) {
+      return NextResponse.json({ error: 'no-session-email' }, { status: 401 });
+    }
+
+    // 2. Look up the Clerk user for this email in the app's Clerk instance.
+    const { clerkClient } = await import('@clerk/nextjs/server');
+    const clerk = await clerkClient();
+    const { data: users } = await clerk.users.getUserList({
+      emailAddress: [email],
+      limit: 1,
+    });
+    const user = users?.[0];
+    if (!user) {
+      // No Clerk account for this email — nothing to manage. Not an error.
+      return NextResponse.json({ hasClerkUser: false });
+    }
+
+    // 3. Mint a short-lived, single-use sign-in ticket for that user. The
+    //    frontend exchanges it for a Clerk session (signIn strategy: 'ticket').
+    const signInToken = await clerk.signInTokens.createSignInToken({
+      userId: user.id,
+      expiresInSeconds: 300, // 5 min — the frontend uses it immediately
+    });
+
+    return NextResponse.json({ hasClerkUser: true, ticket: signInToken.token });
+  } catch (error) {
+    console.error('[clerk-bridge] failed to mint sign-in ticket:', error);
+    return NextResponse.json({ error: 'bridge-failed' }, { status: 500 });
+  }
+}

--- a/src/components/auth/ClerkAccountMenuItem.tsx
+++ b/src/components/auth/ClerkAccountMenuItem.tsx
@@ -1,23 +1,81 @@
 'use client';
 
 /**
- * Dropdown item that opens Clerk's account modal from the existing header user
- * menu — so we don't need a second Clerk avatar in the header. Email
- * management renders natively in the modal (the employeeapp instance enables
- * it), so no custom page is needed.
+ * Dropdown item that opens Clerk's account modal ("Manage account") from the
+ * header user menu.
  *
- * Rendered ONLY when IS_V4 (i.e. inside ClerkProvider), so useClerk is safe.
+ * Clerk's openUserProfile() needs a real Clerk session. Users who signed in via
+ * Clerk already have one. Users who signed in via the Email 1-Time Code (OTP)
+ * flow only have a custom otp_session cookie — no Clerk session — so the modal
+ * would silently do nothing. For those, we transparently establish a Clerk
+ * session first: POST /api/auth/clerk-bridge mints a single-use sign-in ticket
+ * for their existing Clerk account, we exchange it (signIn strategy 'ticket'),
+ * then open the modal. No Clerk user is ever created — if there's no Clerk
+ * account for the email, we degrade gracefully.
+ *
+ * Rendered ONLY when IS_V4 (i.e. inside ClerkProvider), so the Clerk hooks are safe.
  */
 
-import { useClerk } from '@clerk/nextjs';
-import { Mail } from 'lucide-react';
+import { useState } from 'react';
+import { useClerk, useAuth, useSignIn } from '@clerk/nextjs';
+import { Mail, Loader2 } from 'lucide-react';
 import { DropdownMenuItem } from '@/components/ui/DropdownMenu';
 
 export function ClerkAccountMenuItem() {
   const { openUserProfile } = useClerk();
+  const { isSignedIn } = useAuth();
+  const { isLoaded, signIn, setActive } = useSignIn();
+  const [busy, setBusy] = useState(false);
+
+  async function handleManageAccount() {
+    // Already have a Clerk session (signed in via Clerk) — just open it.
+    if (isSignedIn) {
+      openUserProfile();
+      return;
+    }
+    // OTP-authenticated: silently bridge into a Clerk session, then open.
+    if (!isLoaded || !signIn || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch('/api/auth/clerk-bridge', { method: 'POST' });
+      const data = (await res.json().catch(() => ({}))) as {
+        hasClerkUser?: boolean;
+        ticket?: string;
+      };
+      if (!res.ok || !data.hasClerkUser || !data.ticket) {
+        // No Clerk account to manage, or the bridge failed — do nothing.
+        return;
+      }
+      const attempt = await signIn.create({
+        strategy: 'ticket',
+        ticket: data.ticket,
+      });
+      if (attempt.status === 'complete' && attempt.createdSessionId) {
+        await setActive({ session: attempt.createdSessionId });
+        openUserProfile();
+      }
+    } catch (err) {
+      console.error('[clerk-bridge] background sign-in failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
-    <DropdownMenuItem onClick={() => openUserProfile()}>
-      <Mail className="w-4 h-4 mr-2" />
+    <DropdownMenuItem
+      // Keep the menu from closing/stealing focus before the async flow can
+      // open the modal.
+      onSelect={(e) => {
+        e.preventDefault();
+        void handleManageAccount();
+      }}
+      disabled={busy}
+    >
+      {busy ? (
+        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+      ) : (
+        <Mail className="w-4 h-4 mr-2" />
+      )}
       Manage account
     </DropdownMenuItem>
   );


### PR DESCRIPTION
### Problem
Clerk's `openUserProfile()` ("Manage account") needs a real Clerk session. Users who sign in via the **Email 1-Time Code (OTP)** flow only get a custom `otp_session` cookie — no Clerk session — so "Manage account" silently did nothing for them. It worked only for Clerk-session users (e.g. password/Google login).

### Fix
Background OTP→Clerk bridge:
- **`POST /api/auth/clerk-bridge`** — verifies the OTP session, finds the user's **existing** Clerk account by email, mints a single-use sign-in ticket (`signInTokens.createSignInToken`). Returns `{ hasClerkUser:false }` (no error) if there's no Clerk account.
- **`ClerkAccountMenuItem`** — if no Clerk session, silently `signIn.create({ strategy:'ticket', ticket })` + `setActive()`, then `openUserProfile()`.

### Safety
- **No Clerk user is ever created** → no provisioning, no `user.created` webhook side effects.
- MAU grows only for OTP users who actually open Manage Account (lazy).
- Users already exist in the (gignology) instance both apps now share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)